### PR TITLE
Correct driedel randomization

### DIFF
--- a/pkg/driedel/driedel.go
+++ b/pkg/driedel/driedel.go
@@ -3,6 +3,7 @@ package driedel
 import (
 	"fmt"
 	"math/rand"
+	"time"
 )
 
 type SpinResult int
@@ -33,9 +34,9 @@ type Driedel struct {
 	randomizer *rand.Rand
 }
 
-// NewDriedel creates a new Driedel with a random initial seed.
+// NewDriedel creates a new Driedel with the current UNIX time in nanoseconds as the initial seed.
 func NewDriedel() *Driedel {
-	return NewDriedelWithSeed(rand.Int63())
+	return NewDriedelWithSeed(time.Now().UnixNano())
 }
 
 // NewDriedelWithSeed creates a new Driedel with the provided seed for the random number generator.

--- a/test/spin.bats
+++ b/test/spin.bats
@@ -8,3 +8,35 @@ setup() {
     assert_output --regexp '^You spun (נ Nun|ג Gimel|ה Hey|ש Shin)!$'
 }
 
+@test "check spin randomization" {
+    # Check that we have a properly randomized driedel
+    # For 15 spins of a driedel, there less than 1 in one billion chance that a letter is not spun.
+    # 1/(4^15) if you want to be pedantic. This has higher confidence than a typical CI system can offer.
+    local nunCount=0
+    local gimelCount=0
+    local heyCount=0
+    local shinCount=0
+    for (( i=0; i < 15; i++ )); do
+        run driedel spin
+        if [ "$output" = "You spun נ Nun!" ]; then
+            $(( nunCount++ )) || true
+        fi
+        if [ "$output" = "You spun ג Gimel!" ]; then
+            $(( gimelCount++ )) || true
+        fi
+        if [ "$output" = "You spun ה Hey!" ]; then
+            $(( heyCount++ )) || true
+        fi
+        if [ "$output" = "You spun ש Shin!" ]; then
+            $(( shinCount++ )) || true
+        fi
+    done
+    echo "Checking that we got at least one nun"
+    assert_not_equal ${nunCount} 0
+    echo "Checking that we got at least one gimel"
+    assert_not_equal ${gimelCount} 0
+    echo "Checking that we got at least one hey"
+    assert_not_equal ${heyCount} 0
+    echo "Checking that we got at least one shin"
+    assert_not_equal ${shinCount} 0
+}


### PR DESCRIPTION
Use the current time in nanos to seed the driedel's randomizer. Go's
default randomizer has completely deterministic behavior. This means
that left unseeded, a randomizer will produce the same results between
runs. This is undesirable for a command line whose results are invoked
separately - we don't want a driedel that spins gimel every single time!

See https://pkg.go.dev/math/rand